### PR TITLE
Remove numpy <2 upper pin

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -13,7 +13,7 @@ source:
   sha256: 846566d2ed96204956357dcbe0d7cd22a560245f8e386e9812a58a06390c4488
 
 build:
-  number: 0
+  number: 1
   noarch: python
 
 outputs:
@@ -31,7 +31,7 @@ outputs:
         - unzip
       run:
         - python >=${{ python_min }}
-        - numpy >=1.19.1,<2
+        - numpy >=1.19.1
         - python-rapidjson >=0.9.1
         - urllib3 >=2.0.7
     tests:


### PR DESCRIPTION
Closes #46.

Upstream `tritonclient` 2.69.0 only requires `numpy >=1.19.1` (verified against the PyPI wheel METADATA), and there is no known incompatibility with NumPy 2.x for this pure-Python client. Drop the `<2` upper pin and bump the build number.

Scope intentionally limited to the numpy change — other potentially-stale runtime pins (protobuf, grpcio, greenlet) are unrelated and can be addressed in a follow-up PR.